### PR TITLE
Fixed some broken links

### DIFF
--- a/src/10-serial-communication/README.md
+++ b/src/10-serial-communication/README.md
@@ -53,5 +53,5 @@ will see the microcontroller as a virtual serial device.
 Now, let's get familiar with the serial module and the serial communication
 tools that your OS offers. Pick a route:
 
-- [*nix](09-serial-communication/nix-tooling.html)
-- [Windows](09-serial-communication/windows-tooling.html)
+- [*nix](10-serial-communication/nix-tooling.html)
+- [Windows](10-serial-communication/windows-tooling.html)


### PR DESCRIPTION
2 links on the '"Serial" communication' page were resulting in 404s