### PR TITLE
Fix some wording in 07 and 08

### DIFF
--- a/src/07-registers/README.md
+++ b/src/07-registers/README.md
@@ -16,18 +16,18 @@ extern crate pg;
 pub fn main() -> ! {
     unsafe {
         // A magic address!
-        const GPIOE_BSRR: u32 = 0x4800_1018;
+        const GPIOE_BSRR: u32 = 0x48001018;
 
-        // Turn on the North LED (red)
+        // Turn on the "North" LED (red)
         *(GPIOE_BSRR as *mut u32) = 1 << 9;
 
-        // Turn on the East LED (green)
+        // Turn on the "East" LED (green)
         *(GPIOE_BSRR as *mut u32) = 1 << 11;
 
-        // Turn off the North LED
+        // Turn off the "North" LED
         *(GPIOE_BSRR as *mut u32) = 1 << (9 + 16);
 
-        // Turn on the East LED
+        // Turn off the "East" LED
         *(GPIOE_BSRR as *mut u32) = 1 << (11 + 16);
     }
 
@@ -37,7 +37,7 @@ pub fn main() -> ! {
 
 What's this magic?
 
-The address `0x4800_1018` points to a *register*. A register is special region
+The address `0x48001018` points to a *register*. A register is special region
 of memory that controls a *peripheral*. A peripheral is a piece of electronics
 that sits right next to the processor within the microcontroller package and
 provides the processor extra functionality. After all, the processor, on its

--- a/src/07-registers/bad-address.md
+++ b/src/07-registers/bad-address.md
@@ -75,11 +75,11 @@ Dump of assembler code for function core::ptr::read_volatile<u32>:
 
 The exception was caused by a `ldr` instruction, a read instruction. The
 instruction tried to read the memory at the address indicated by the `r0`
-register. BTW, `r0` is a CPU (processor) register not a microcontroller
+register. By the way, `r0` is a CPU (processor) register not a microcontroller
 register.
 
-Wouldn't it be nice if we could check what was the value of the `r0` register
-right at the instant at which the exception was raised? Well, we can!
+Wouldn't it be nice if we could check what the value of the `r0` register was
+right at the instant when the exception was raised? Well, we can!
 
 If you looked carefully at the GDB output right when the exception was hit, you
 probably saw this:

--- a/src/07-registers/optimization.md
+++ b/src/07-registers/optimization.md
@@ -6,8 +6,9 @@ values to the same register. If you didn't know that address was a register, you
 may have simplified the logic to just write the final value `1 << (11 + 16)`
 into the register.
 
-Actually, LLVM does not know this is a register and will merge the writes thus
-changing the behavior of our program. Let's check that really quick.
+Actually, LLVM, the compiler, does not know this is a register and will merge
+the writes thus changing the behavior of our program. Let's check that really
+quick.
 
 ```
 $ xargo build --target thumbv7em-none-eabihf --release
@@ -87,7 +88,7 @@ pub fn main() -> ! {
         // Turn off the "North" LED
         ptr::write_volatile(GPIOE_BSRR as *mut u32, 1 << (9 + 16));
 
-        // Turn on the "East" LED
+        // Turn off the "East" LED
         ptr::write_volatile(GPIOE_BSRR as *mut u32, 1 << (11 + 16));
     }
 

--- a/src/07-registers/src/main.rs
+++ b/src/07-registers/src/main.rs
@@ -19,7 +19,7 @@ pub fn main() -> ! {
         // Turn off the "North" LED
         *(GPIOE_BSRR as *mut u32) = 1 << (9 + 16);
 
-        // Turn on the "East" LED
+        // Turn off the "East" LED
         *(GPIOE_BSRR as *mut u32) = 1 << (11 + 16);
     }
 

--- a/src/07-registers/type-safe-manipulation.md
+++ b/src/07-registers/type-safe-manipulation.md
@@ -69,11 +69,11 @@ more human friendly: `gpioe.bsrr` to refer to the `BSRR` register in the `GPIOE`
 register block.
 
 Then we have this `write` method that takes a closure. If the "identity" closure
-is used: `|w| w`, this method will set the register to its "reset value", the
+is used (`|w| w`), this method will set the register to its "reset value", the
 value it had right after the microcontroller was powered on / reset. That value
 is `0x0` for the `BSRR` register. Since we want to write a non-zero value to the
-register, we use builder methods like `bs9` to set (`true`) or reset (`false`)
-some of the bits of the register value.
+register, we use builder methods like `bs9` to set (`true`) or `br9` reset
+(`false`) some of the bits of the register value.
 
 Let's run this program! There's some interesting stuff we can do *while*
 debugging the program.
@@ -87,8 +87,8 @@ $1 = (f3::peripheral::gpio::Gpio *) 0x48001000
 ```
 
 But if we instead `print *gpioe`, we'll get a "full view" of the register block.
-The value of each of its registers will be printed. I recommend setting `set
-print pretty on` first, though, to make the output more readable.
+The value of each of its registers will be printed. I recommend enabling pretty
+print (`set print pretty on`) first, though, to make the output more readable.
 
 ```
 (gdb) set print pretty on

--- a/src/08-leds-again/README.md
+++ b/src/08-leds-again/README.md
@@ -2,7 +2,7 @@
 
 In the last section, I gave you "initialized" peripherals (I initialized them
 before `main`). That's why just writing to `BSRR` was enough to control the
-LEDs. But, peripheral are not "initialized" right after the microcontroller
+LEDs. But, peripherals are not "initialized" right after the microcontroller
 boots.
 
 In this section, you'll have more "fun" with registers: You'll have to configure

--- a/src/08-leds-again/power.md
+++ b/src/08-leds-again/power.md
@@ -19,7 +19,7 @@ The registers that control the power status of other peripherals are:
 Each bit in these registers controls the power status of a single peripheral,
 including `GPIOE`.
 
-Your task is this section is to power on the `GPIOE` peripheral. You'll have to:
+Your task in this section is to power on the `GPIOE` peripheral. You'll have to:
 
 - Figure out which of the three registers I mentioned before has the bit that
   controls the power status.


### PR DESCRIPTION
1. A few typos, e.g. peripheral vs peripheralS.
2. Made sure the code in 07/README matched the actual code.
3. Fixed a few comments where it said 'turn on' when it was actually 'turn off'.
4. A few wording fixes.