### PR TITLE
Fix in chapter 9: set OPM and clear CEN (for one pulse mode)

### DIFF
--- a/src/09-clocks-and-timers/initialization.md
+++ b/src/09-clocks-and-timers/initialization.md
@@ -19,7 +19,7 @@ First, we'll have to configure the timer to operate in one pulse mode.
 ``` rust
     // OPM Select one pulse mode
     // CEN Keep the counter disabled for now
-    tim6.cr1.write(|w| w.opm().clear_bit().cen().set_bit());
+    tim6.cr1.write(|w| w.opm().set_bit().cen().clear_bit());
 ```
 
 Then, we'll like to have the `CNT` counter operate at a frequency of 1 KHz because our `delay`

--- a/src/09-clocks-and-timers/putting-it-all-together.md
+++ b/src/09-clocks-and-timers/putting-it-all-together.md
@@ -31,7 +31,7 @@ fn main() {
 
     // OPM Select one pulse mode
     // CEN Keep the counter disabled for now
-    tim6.cr1.write(|w| w.opm().clear_bit().cen().set_bit());
+    tim6.cr1.write(|w| w.opm().set_bit().cen().clear_bit());
 
     // Configure the prescaler to have the counter operate at 1 KHz
     // APB1_CLOCK = 8 MHz


### PR DESCRIPTION
First of all, thanks for your great job in the world of programming microcontrollers in rust!
I believe the bit set and clear were mixed up. The registers are explained in the page 678 of the user manual.
Thanks!