### PR TITLE
Point out source of "duplicate lang item"

### DIFF
--- a/src/05-led-roulette/build-it.md
+++ b/src/05-led-roulette/build-it.md
@@ -45,6 +45,8 @@ $ cargo build --target thumbv7em-none-eabihf
 
 > **NOTE** Be sure to compile this crate *without* optimizations
 
+> **NOTE** If you get errors like ``duplicate lang item found: `panic_fmt` ``, make sure you have changed into the `src/05-led-roulette` directory.
+
 OK, now we have produced an executable. As a sanity check, let's verify that the produced executable
 is actually an ARM binary:
 


### PR DESCRIPTION
If a reader does not carefully follow the previous page's steps (the "Jump into" step is meant as a `cd`, not just browse there), a reader might (ok, I did) execute the `cargo build` in the discovery directory.

With the error message that ensues (``duplicate lang item found: `panic_fmt`.``), it make take some time for the reader to find the mistake (mine: 5min); a cautionary note might save others that time.