### PR TITLE
Correct page numbers in 09-clocks-and-timers

### DIFF
--- a/src/09-clocks-and-timers/one-shot-timer.md
+++ b/src/09-clocks-and-timers/one-shot-timer.md
@@ -13,11 +13,11 @@ The microcontroller we are using has several (in fact, more than 10) timers of d
 We'll be using one of the *basic* timers: `TIM6`. This is one of the simplest timers available in
 our microcontroller. The documentation for basic timers is in the following section:
 
-> Section 22 Timers - Page 674 - Reference Manual
+> Section 22 Timers - Page 670 - Reference Manual
 
 Its registers are documented in:
 
-> Section 22.4.9 TIM6/TIM7 register map - Page 686 - Reference Manual
+> Section 22.4.9 TIM6/TIM7 register map - Page 682 - Reference Manual
 
 The registers we'll be using in this section are:
 


### PR DESCRIPTION
This corrects the page numbers per the version of the reference manual linked below.

https://www.st.com/content/ccc/resource/technical/document/reference_manual/4a/19/6e/18/9d/92/43/32/DM00043574.pdf/files/DM00043574.pdf/jcr:content/translations/en.DM00043574.pdf