### PR TITLE
Fix LED Compass project GDB breakpoint

### DIFF
--- a/src/15-led-compass/.gdbinit
+++ b/src/15-led-compass/.gdbinit
@@ -4,5 +4,5 @@ set print pretty on
 monitor tpiu config internal itm.txt uart off 8000000
 monitor itm port 0 on
 load
-break main
+break led_compass::main
 continue


### PR DESCRIPTION
This fix causes the project to break at the normal start of the user's `main` function as it does in all of the other examples, allowing `layout src` to immediately work.