### PR TITLE
Fix issue #490: udev rule not working correctly on Arch Linux

### DIFF
--- a/microbit/src/03-setup/linux.md
+++ b/microbit/src/03-setup/linux.md
@@ -60,12 +60,12 @@ These rules let you use USB devices like the micro:bit without root privilege, i
 Create this file in `/etc/udev/rules.d` with the content shown below.
 
 ``` console
-$ cat /etc/udev/rules.d/99-microbit.rules
+$ cat /etc/udev/rules.d/70-microbit.rules
 ```
 
 ``` text
 # CMSIS-DAP for microbit
-SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE:="666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="0660", TAG+="uaccess"
 ```
 
 Then reload the udev rules with:


### PR DESCRIPTION
As per issue #490, the current udev rule does not work correctly on Arch Linux.

This change is based on udev rules from [probe-rs](https://probe.rs/docs/getting-started/probe-setup/#udev-rules).

This new rule should work fine on any Linux distribution using systemd (or elogind), but I am unsure if it will also work on non-systemd distributions.