### PR TITLE
terminology: crate `nrf51` has been renamed to `nrf51-pac`

### DIFF
--- a/microbit/src/04-meet-your-hardware/terminology.md
+++ b/microbit/src/04-meet-your-hardware/terminology.md
@@ -37,7 +37,7 @@ does actually have a [BSP] so we are going to use that on top of our
 HAL as well.
 
 [nrF52]: https://crates.io/crates/nrf52833-pac
-[nrF51]: https://crates.io/crates/nrf51
+[nrF51]: https://crates.io/crates/nrf51-pac
 [nrF52-hal]: https://crates.io/crates/nrf52833-hal
 [nrF51-hal]: https://crates.io/crates/nrf51-hal
 [BSP]: https://crates.io/crates/microbit


### PR DESCRIPTION
See https://docs.rs/nrf51/0.10.0/nrf51/