### PR TITLE
update links to product specification

### DIFF
--- a/microbit/src/04-meet-your-hardware/microbit-v1.md
+++ b/microbit/src/04-meet-your-hardware/microbit-v1.md
@@ -24,7 +24,7 @@ dedicated to explaining the weird chip naming. Here we learn that:
 [QFN48]: https://en.wikipedia.org/wiki/Flat_no-leads_package
 [Nordic Semiconductor]: https://www.nordicsemi.com/
 [product page]: https://www.nordicsemi.com/products/nrf51822
-[product specification]: https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.3.pdf
+[product specification]: https://docs.nordicsemi.com/bundle/nRF51822_PS/resource/nRF51822_PS_v3.3.pdf
 
 - The `N51` is the MCU's series, indicating that there are other `nRF51` MCUs
 - The `822` is the part code

--- a/microbit/src/04-meet-your-hardware/microbit-v2.md
+++ b/microbit/src/04-meet-your-hardware/microbit-v2.md
@@ -24,7 +24,7 @@ dedicated to explaining the weird chip naming. Here we learn that:
 [aQFN73]: https://en.wikipedia.org/wiki/Flat_no-leads_package
 [Nordic Semiconductor]: https://www.nordicsemi.com/
 [product page]: https://www.nordicsemi.com/products/nrf52833
-[product specification]: https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.3.pdf
+[product specification]: https://docs.nordicsemi.com/bundle/nRF52833-PS/resource/nRF52833_PS_v1.3.pdf
 
 - The `N52` is the MCU's series, indicating that there are other `nRF52` MCUs
 - The `833` is the part code


### PR DESCRIPTION
I notice that the links are broken because nordicsemi change something. I put the same version (`v3.3` and `v1.3`).

The nRF52833 has an even [newer version](https://docs.nordicsemi.com/bundle/ps_nrf52833/page/keyfeatures_html5.html) (`v1.7), I don't know if it needs to be changed.