### PR TITLE
choose correct thumbnails size for mediawiki img

### DIFF
--- a/f3discovery/src/10-serial-communication/README.md
+++ b/f3discovery/src/10-serial-communication/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://en.wikipedia.org/wiki/File:Serial_port.jpg">
 <p align="center">
-<img height="240" title="Standard serial port connector DE-9" src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Serial_port.jpg/800px-Serial_port.jpg">
+<img height="240" title="Standard serial port connector DE-9" src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Serial_port.jpg/960px-Serial_port.jpg">
 </p>
 </a>
 

--- a/microbit/src/06-serial-communication/README.md
+++ b/microbit/src/06-serial-communication/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://en.wikipedia.org/wiki/File:Serial_port.jpg">
 <p align="center">
-<img height="240" title="Standard serial port connector DE-9" src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Serial_port.jpg/800px-Serial_port.jpg">
+<img height="240" title="Standard serial port connector DE-9" src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Serial_port.jpg/960px-Serial_port.jpg">
 </p>
 </a>
 


### PR DESCRIPTION
I found a broken img to wikimedia and it's because the wiki try to standardize the size of the thrumbnails ([more info](https://www.mediawiki.org/wiki/Common_thumbnail_sizes) but TLDR: the 800px don't work but the next standard step 960px works).